### PR TITLE
Patch stream2 writable

### DIFF
--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -61,6 +61,8 @@ function GridWriteStream (grid, options) {
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
+  this._delayedFlush = null;
+
   var self = this;
 
   self._open();
@@ -93,17 +95,18 @@ GridWriteStream.prototype._open = function () {
     self._opened = true;
     self.emit('open');
 
+    // If _flush was called during _store opening, then it was delayed until now, so do the flush now (it's necessarily an empty GridFS file, no _write could have been called and have finished)
+    if (self._delayedFlush) {
+      var flushed = self._delayedFlush;
+      self._delayedFlush = null;
+      self._flushInternal(flushed);
+    }
+
     // If data was sent before store is open start writing to the store
     if (self._delayedWrite) {
       var delayedWrite = self._delayedWrite;
       self._delayedWrite = null;
       return self._writeInternal(delayedWrite.chunk, delayedWrite.encoding, delayedWrite.done);
-    }
-
-    // If empty file
-    if (self._needToFlush  && !this._writePending) {
-      self._needToFlush();
-      self._close();
     }
   });
 }
@@ -122,20 +125,12 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
   // Write the chunk to the GridStore. The write head automatically moves along with each write.
   this._store.write(chunk, function (err, store) {
     if (err) return self._error(err);
-    self._writePending = false;
 
     // Emit the write head position
     self.emit('progress', store.position);
 
     // We are ready to receive a new chunk from the writestream - call done().
     done();
-
-    // If we received an indication to flush - call _needToFlush and close the store.
-    if (self._needToFlush) {
-      self._needToFlush();
-      self._close();
-    }
-
   });
 }
 
@@ -146,9 +141,6 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // Used to know if its OK to close the store after an indication to flush is received.
-  this._writePending = true;
-
   // The store is not open but data is ready to be written so delay the write until the store is opened.
   if (!this._opened) {
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
@@ -160,20 +152,33 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
 }
 
 /**
+ * _flushInternal
+ *
+ * @api private
+ */
+
+GridWriteStream.prototype._flushInternal = function (flushed) {
+  flushed();
+  this._close();
+}
+
+/**
  * _flush
  *
  * @api private
  */
 
 GridWriteStream.prototype._flush = function (flushed) {
-  // If no write is pending then complete the flush
-  if (!this._writePending && this._opened) {
-    flushed();
-    return this._close();
+  // _flush is called when all _write() have finished (even if no _write() was called (empty GridFS file))
+
+  if (this._opening) {
+    // if we are still opening the store, then delay the flush until it is open.
+    this._delayedFlush = flushed;
+    return;
   }
 
-  // If write outstanding defer the callback until it completes. Save the flushed callback and call it in the write method or after store opens if its an empty file.
-  this._needToFlush = flushed;
+  // otherwise, do the flush now
+  this._flushInternal(flushed);
 }
 
 /**

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -194,6 +194,7 @@ GridWriteStream.prototype._close = function _close (cb) {
 
   var self = this;
   this._store.close(function (err, file) {
+    self._closing = false;
     if (err) return self._error(err);
     self.emit('close', file);
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -82,11 +82,13 @@ util.inherits(GridWriteStream, FlushWritable);
  */
 
 GridWriteStream.prototype._open = function () {
+  if (this._opened) return;
   if (this._opening) return;
   this._opening = true;
 
   var self = this;
   this._store.open(function (err, gs) {
+    self._opening = false;
     if (err) return self._error(err);
     self._opened = true;
     self.emit('open');

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -159,8 +159,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._flushInternal = function (flushed) {
-  flushed();
-  this._close();
+  this._close(flushed);
 }
 
 /**
@@ -188,7 +187,7 @@ GridWriteStream.prototype._flush = function (flushed) {
  * @api private
  */
 
-GridWriteStream.prototype._close = function _close () {
+GridWriteStream.prototype._close = function _close (cb) {
   if (!this._opened) return;
   if (this._closing) return;
   this._closing = true;
@@ -197,6 +196,8 @@ GridWriteStream.prototype._close = function _close () {
   this._store.close(function (err, file) {
     if (err) return self._error(err);
     self.emit('close', file);
+
+    if (cb) cb();
   });
 }
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -61,6 +61,7 @@ function GridWriteStream (grid, options) {
   // in the call signature, which is what we want.
   this._store = new grid.mongo.GridStore(grid.db, this.id, this.name, this.mode, this.options);
 
+  this._delayedWrite = null;
   this._delayedFlush = null;
 
   var self = this;
@@ -102,7 +103,7 @@ GridWriteStream.prototype._open = function () {
       self._flushInternal(flushed);
     }
 
-    // If data was sent before store is open start writing to the store
+    // If _write was called during _store opening, then it was delayed until now, so do the write now
     if (self._delayedWrite) {
       var delayedWrite = self._delayedWrite;
       self._delayedWrite = null;
@@ -141,13 +142,13 @@ GridWriteStream.prototype._writeInternal = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._write = function (chunk, encoding, done) {
-  // The store is not open but data is ready to be written so delay the write until the store is opened.
-  if (!this._opened) {
+  if (this._opening) {
+    // if we are still opening the store, then delay the write until it is open.
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
     return;
   }
 
-  // The store is open so pass all arguments to _writeInternal to be written to the gridstore
+  // otherwise, do the write now
   this._writeInternal(chunk, encoding, done);
 }
 

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -92,7 +92,11 @@ GridWriteStream.prototype._open = function () {
     self.emit('open');
 
     // If data was sent before store is open start writing to the store
-    if (self._delayedWrite) return self._writeInternal(self._delayedWrite.chunk, self._delayedWrite.encoding, self._delayedWrite.done);
+    if (self._delayedWrite) {
+      var delayedWrite = self._delayedWrite;
+      self._delayedWrite = null;
+      return self._writeInternal(delayedWrite.chunk, delayedWrite.encoding, delayedWrite.done);
+    }
 
     // If empty file
     if (self._needToFlush  && !this._writePending) {

--- a/lib/writestream.js
+++ b/lib/writestream.js
@@ -6,7 +6,7 @@
 var util = require('util');
 //var Writable  = require('stream').Writable;
 
-// This is a workaround to implement a _flush method for Writable (like for Transform) to indicate that all data has been flushed to the underlying system. See https://www.npmjs.com/package/flushwritable and https://github.com/joyent/node/issues/7348
+// This is a workaround to implement a _flush method for Writable (like for Transform) to emit the 'finish' event only after all data has been flushed to the underlying system (GridFS). See https://www.npmjs.com/package/flushwritable and https://github.com/joyent/node/issues/7348
 var FlushWritable = require('flushwritable');
 
 /**
@@ -81,7 +81,7 @@ util.inherits(GridWriteStream, FlushWritable);
  * @api private
  */
 
-GridWriteStream.prototype._open = function _open () {
+GridWriteStream.prototype._open = function () {
   if (this._opening) return;
   this._opening = true;
 
@@ -146,7 +146,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
   // The store is not open but data is ready to be written so delay the write until the store is opened.
   if (!this._opened) {
     this._delayedWrite = {chunk: chunk, encoding: encoding, done: done};
-    return
+    return;
   }
 
   // The store is open so pass all arguments to _writeInternal to be written to the gridstore
@@ -160,7 +160,7 @@ GridWriteStream.prototype._write = function (chunk, encoding, done) {
  */
 
 GridWriteStream.prototype._flush = function (flushed) {
-  // If all data has been flushed to the gridstore call flushed and close the store.
+  // If no write is pending then complete the flush
   if (!this._writePending && this._opened) {
     flushed();
     return this._close();

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "flushwritable": "*"
+    "flushwritable": "^1.0.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Here is a review with fixes and cleanups on top of your master, for Writable stream only.

The important part is that _flush must call its callback only when the file exists in GridFS (we should probably write a test: on 'finish' event, check that the file exists in GridFS). Your current master called the _flush callback when all _write finished, but _flush is already called only when all _write are finished.
With this guarantee I also simplified the code a lot (no need for _writePending flag).

Pending questions:
- `open` and `close` event should be explicitly documented as they are _not_ part of the Stream2 standard API (for a Writable stream): they are linked to the opening and the closing of the _store, with _store.close() meaning that the file has been written to GridFS.
- I don't know what we should do in case of error:
  - Internally:
    Currently we just call _error() which emits `error` and then _close(). It works, but we could do other things:
    _write and _flush give callbacks that accept an error as first argument. If there is either a _write or a _flush (we cannot have both at the same time) running during the error (for example _store.open() failed, or _store.write() failed, or _store.close() failed), then we could (also?) call that callback with the error.
    From what I read in the code of nodejs v0.10.31 and v0.12.0, both with indirectly emit `error`, and the _write() callback will call the optional write() callback so the caller will be notified too.
    It may be useful to notify the caller this way, but it's harder to do it properly: we need to avoid multiple `error` emitted, and we still need to call _close() (and maybe in a precise order: it may be useful to guarantee that 'error' happens before (or after?) 'close'; for that we could delay _close() to nextTick).
    I don't know what is the best practice here... Maybe we should ask on nodejs mailing list?
  - externally:
    We always call _store.close(), so we always `commit` the file to GridFS by writing the document in the `files` collection.
    This may not be the best solution in case of error: If an error happened, the file may be corrupted, but we store it like no error happened.
    Two solutions:
  - keep commiting the file to GridFS, but add an extra metadata field `error` to notify that this file may be corrupted. It would be up to the caller to remove the file afterward if it wants that, or not.
  - remove the file and the chunks on error, because the file is likely corrupted, but it's an issue if the file was overwriting another file, because we would want to rollback to a previous state (which is what we would expect. It's how AWS S3 works for example), and the current GridStore from nodejs mongodb driver 2.0.15 deletes the old chunks before starting to write the new ones, so we cannot... Maybe it's a bug of the mongodb driver, but I don't see how it could implement what we want without performance issues.
- I haven't reviewed the `destroy` method yet. It's related to the previous question about error handling anyway. We could also add an optional error argument that would be emitted with `error` (and maybe also passed to callbacks as error..). I'm pretty sure the current `destroy` is invalid as it aborts the writing without emitting `error`.

I haven't reviewed the Readable stream either yet, I'm less familiar with Readble streams than with Writable ones...

I'm not sure about the github flow here: will it work if you merge this PR in your fork, then PR the upstream project (aheckmann)? Or maybe I can PR directly to aheckmann ?
